### PR TITLE
feat: Enable gRPC port

### DIFF
--- a/charts/poktroll-sequencer/templates/deployment.yaml
+++ b/charts/poktroll-sequencer/templates/deployment.yaml
@@ -36,6 +36,8 @@ spec:
               name: rpc
             - containerPort: 40004 # TODO(@okdas): remove this - currently only needed for LocalNet dlv
               name: debug
+            - containerPort: {{ .Values.service.grpcPort }}
+              name: grpc
           livenessProbe:
             httpGet:
               path: /

--- a/charts/poktroll-sequencer/templates/scripts.yaml
+++ b/charts/poktroll-sequencer/templates/scripts.yaml
@@ -34,8 +34,8 @@ data:
 
     # start the node
     # You can attach to this process with delve (dlv) for debugging purpose with `dlv attach $(pgrep poktrolld) --listen :40004 --headless --api-version=2 --accept-multiclient` - run inside the container!
-    poktrolld start --rollkit.aggregator=true --rollkit.da_layer=celestia --rollkit.da_config='{"base_url":"http://{{ .Values.dataAvailability.celestia.hostname }}:26658","timeout":60000000000,"fee":600000,"gas_limit":6000000,"auth_token":"'$AUTH_TOKEN'"}' --rollkit.namespace_id=$NAMESPACE --rollkit.da_start_height=$DA_BLOCK_HEIGHT --rpc.laddr=tcp://0.0.0.0:36657 --p2p.laddr="0.0.0.0:36656"
+    poktrolld start --rollkit.aggregator=true --rollkit.da_layer=celestia --rollkit.da_config='{"base_url":"http://{{ .Values.dataAvailability.celestia.hostname }}:26658","timeout":60000000000,"fee":600000,"gas_limit":6000000,"auth_token":"'$AUTH_TOKEN'"}' --rollkit.namespace_id=$NAMESPACE --rollkit.da_start_height=$DA_BLOCK_HEIGHT --rpc.laddr=tcp://0.0.0.0:36657 --p2p.laddr="0.0.0.0:36656" --grpc.address=0.0.0.0:36658
 
     # OR debug the node (uncomment this line but comment previous line)
-    # dlv exec /usr/local/bin/poktrolld --listen :40004 --headless --api-version=2 --accept-multiclient -- start --rollkit.aggregator=true --rollkit.da_layer=celestia --rollkit.da_config='{"base_url":"http://{{ .Values.dataAvailability.celestia.hostname }}:26658","timeout":60000000000,"fee":600000,"gas_limit":6000000,"auth_token":"'$AUTH_TOKEN'"}' --rollkit.namespace_id=$NAMESPACE --rollkit.da_start_height=$DA_BLOCK_HEIGHT --rpc.laddr=tcp://0.0.0.0:36657 --p2p.laddr="0.0.0.0:36656"
+    # dlv exec /usr/local/bin/poktrolld --listen :40004 --headless --api-version=2 --accept-multiclient -- start --rollkit.aggregator=true --rollkit.da_layer=celestia --rollkit.da_config='{"base_url":"http://{{ .Values.dataAvailability.celestia.hostname }}:26658","timeout":60000000000,"fee":600000,"gas_limit":6000000,"auth_token":"'$AUTH_TOKEN'"}' --rollkit.namespace_id=$NAMESPACE --rollkit.da_start_height=$DA_BLOCK_HEIGHT --rpc.laddr=tcp://0.0.0.0:36657 --p2p.laddr="0.0.0.0:36656" --grpc.address=0.0.0.0:36658
 

--- a/charts/poktroll-sequencer/templates/service.yaml
+++ b/charts/poktroll-sequencer/templates/service.yaml
@@ -11,3 +11,7 @@ spec:
       name: rpc
       port: 36657
       targetPort: 36657
+    - protocol: TCP
+      name: grpc
+      port: 36658
+      targetPort: 36658

--- a/charts/poktroll-sequencer/values.yaml
+++ b/charts/poktroll-sequencer/values.yaml
@@ -10,8 +10,9 @@ image:
 service:
   type: ClusterIP
   rpcPort: 36657
+  grpcPort: 36658
 pvc:
-  accessModes: 
+  accessModes:
     - ReadWriteOnce
   requests:
     storage: 1Gi


### PR DESCRIPTION
Enable gRPC listener on `poktroll-sequencer` to be used by the off-chain clients `AppGateServer`, `RelayMiner` and `POKTRollSDK`

Related to [poktroll/issues/259](https://github.com/pokt-network/poktroll/issues/259)