### PR TITLE
fix: switch to tx node rpc url

### DIFF
--- a/charts/appgate-server/values.yaml
+++ b/charts/appgate-server/values.yaml
@@ -23,10 +23,7 @@ config:
   # Pocket node URL that exposes CometBFT JSON-RPC API.
   # This can be used by the Cosmos client SDK, event subscriptions, etc...
   query_node_rpc_url: tcp://poktroll-sequencer:36657
-  # Pocket node URL that exposes the Cosmos gRPC service.
-  tx_node_grpc_url: tcp://poktroll-sequencer:36658
   # Pocket node URL that exposes the Cosmos gRPC service, dedicated to querying purposes.
-  # If unspecified, defaults to `tx_node_grpc_url`.
   query_node_grpc_url: tcp://poktroll-sequencer:36658
 
 keyringBackend: test

--- a/charts/poktroll-sequencer/templates/scripts.yaml
+++ b/charts/poktroll-sequencer/templates/scripts.yaml
@@ -45,7 +45,7 @@ data:
 
     # IMPORTANT: Any flags that need to be used to modify the sequencer's behaviour (e.g. block time) can be modified
     # on the following line. See the following link for the full parameter list: https://github.com/rollkit/rollkit/blob/main/config/config.go
-    
+
     # You can attach to this process with delve (dlv) for debugging purpose with `dlv attach $(pgrep poktrolld) --listen :40004 --headless --api-version=2 --accept-multiclient` - run inside the container!
     poktrolld start --home=/root/.pocket/ --rollkit.aggregator=true --rollkit.da_layer=celestia --rollkit.da_config='{"base_url":"{{ .Values.dataAvailability.celestia.da_rpc_url }}","timeout":{{ printf "%.0f" .Values.dataAvailability.timeout }},"fee":{{ printf "%.0f" .Values.dataAvailability.fee }},"gas_limit":{{ printf "%.0f" .Values.dataAvailability.gas_limit }},"auth_token":"'$AUTH_TOKEN'"}' --rollkit.namespace_id=$NAMESPACE --rollkit.da_start_height=$DA_BLOCK_HEIGHT --rpc.laddr=tcp://0.0.0.0:36657 --p2p.laddr="0.0.0.0:36656" --grpc.address=0.0.0.0:36658
 

--- a/charts/relayminer/Chart.yaml
+++ b/charts/relayminer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.1.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/relayminer/values.yaml
+++ b/charts/relayminer/values.yaml
@@ -19,7 +19,7 @@ config:
   pocket_node:
     query_node_rpc_url: tcp://poktroll-sequencer:36657
     query_node_grpc_url: tcp://poktroll-sequencer:36658
-    tx_node_grpc_url: tcp://poktroll-sequencer:36658
+    tx_node_rpc_url: tcp://poktroll-sequencer:36657
   proxies:
     - proxy_name: http-proxy
       type: http


### PR DESCRIPTION
Since transaction broadcasting needs to go through `Tendermint`'s RPC instead of gRPC URL, the config entry is renamed to `tx_node_rpc_url` and the port changed to the adequate value.