### PR TITLE
Add `--home` flag to offchain actors

### DIFF
--- a/charts/appgate-server/templates/deployment.yaml
+++ b/charts/appgate-server/templates/deployment.yaml
@@ -36,10 +36,19 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           command: ["poktrolld"]
+          # command: ["dlv"]
           args: 
+            #- "exec"
+            #- "--listen=:40006"
+            #- "--headless=true"
+            #- "--api-version=2"
+            #- "--accept-multiclient"
+            #- "/usr/local/bin/poktrolld"
+            #- "--"
             - "appgate-server"
             - "--keyring-backend={{ .Values.keyringBackend }}"
             - "--config=/pocket/config/config.yaml"
+            - "--home=/root/.pocket/"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
@@ -48,6 +57,8 @@ spec:
             - name: metrics
               containerPort: {{ .Values.metrics.port }}
               protocol: TCP
+            - containerPort: 40006 # TODO(@okdas): remove this - currently only needed for LocalNet dlv
+              name: debug
           # TODO(@okdas): enable health checks
           # livenessProbe:
           #   httpGet:

--- a/charts/relayminer/templates/deployment.yaml
+++ b/charts/relayminer/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           command: ["poktrolld"]
           # command: ["dlv"]
-          # args:
+          args:
           #   - "exec"
           #   - "--listen=:40005"
           #   - "--headless=true"

--- a/charts/relayminer/templates/deployment.yaml
+++ b/charts/relayminer/templates/deployment.yaml
@@ -36,10 +36,19 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           command: ["poktrolld"]
-          args: 
+          # command: ["dlv"]
+          # args:
+          #   - "exec"
+          #   - "--listen=:40005"
+          #   - "--headless=true"
+          #   - "--api-version=2"
+          #   - "--accept-multiclient"
+          #   - "/usr/local/bin/poktrolld"
+          #   - "--"
             - "relayminer"
             - "--keyring-backend={{ .Values.keyringBackend }}"
             - "--config=/pocket/config/config.yaml"
+            - "--home=/root/.pocket/"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
@@ -48,6 +57,8 @@ spec:
             - name: metrics
               containerPort: {{ .Values.metrics.port }}
               protocol: TCP
+            - containerPort: 40005 # TODO(@okdas): remove this - currently only needed for LocalNet dlv
+              name: debug
           # TODO(@okdas): enable health checks
           # livenessProbe:
           #   httpGet:


### PR DESCRIPTION
`RelayMiner` and `AppGateServer` could not find their keynames without pointing them to their home directory.

* Add `--home` flag to their deployment files
* Added commented dlv flags for easy debug switching
* Added debugging port to their containers