### PR TITLE
feat(relayminer): Expose additional port for ping server

### DIFF
--- a/charts/relayminer/templates/deployment.yaml
+++ b/charts/relayminer/templates/deployment.yaml
@@ -92,6 +92,9 @@ spec:
             - name: metrics
               containerPort: {{ .Values.metrics.port }}
               protocol: TCP
+            - name: status
+              containerPort: {{ .Values.ping.port }}
+              protocol: TCP
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/relayminer/templates/service.yaml
+++ b/charts/relayminer/templates/service.yaml
@@ -15,5 +15,9 @@ spec:
       targetPort: {{ .Values.metrics.port }}
       protocol: TCP
       name: metrics
+    - port: {{ .Values.ping.port }}
+      targetPort: {{ .Values.ping.port }}
+      protocol: TCP
+      name: status
   selector:
     {{- include "relayminer.selectorLabels" . | nindent 4 }}

--- a/charts/relayminer/values.yaml
+++ b/charts/relayminer/values.yaml
@@ -45,6 +45,9 @@ config:
     enabled: true
     # If changing port here, make sure to adjust `metrics.serviceMonitor.port`
     addr: :9090
+  ping:
+    enabled: true
+    addr: :8081
   pprof:
     enabled: true
     addr: localhost:6060
@@ -73,6 +76,9 @@ metrics:
   serviceMonitor:
     enabled: false
   port: 9090
+
+ping:
+  port: 8081
 
 podAnnotations: {}
 podLabels: {}


### PR DESCRIPTION
This PR exposes a additional port to the relayminer chart for the Ping server.

More context is available here https://github.com/pokt-network/poktroll/pull/744