### PR TITLE
[Relayminer] refactor: remove publicly_exposed_endpoints from relayminer config

### DIFF
--- a/charts/relayminer/README.md
+++ b/charts/relayminer/README.md
@@ -27,12 +27,10 @@ A Helm chart for Kubernetes
 | config.smt_store_path | string | `"smt_stores"` |  |
 | config.suppliers[0].listen_url | string | `"http://0.0.0.0:8545"` |  |
 | config.suppliers[0].service_config.backend_url | string | `"http://anvil:8547/"` |  |
-| config.suppliers[0].service_config.publicly_exposed_endpoints[0] | string | `"relayminers"` |  |
 | config.suppliers[0].service_id | string | `"anvil"` |  |
 | config.suppliers[0].type | string | `"http"` |  |
 | config.suppliers[1].listen_url | string | `"ws://0.0.0.0:8545"` |  |
 | config.suppliers[1].service_config.backend_url | string | `"ws://anvil:8547/"` |  |
-| config.suppliers[1].service_config.publicly_exposed_endpoints[0] | string | `"relayminers"` |  |
 | config.suppliers[1].service_id | string | `"anvilws"` |  |
 | config.suppliers[1].type | string | `"http"` |  |
 | development.delve.enabled | bool | `false` |  |

--- a/charts/relayminer/values.yaml
+++ b/charts/relayminer/values.yaml
@@ -38,15 +38,11 @@ config:
       type: http
       service_config:
         backend_url: http://anvil:8547/
-        publicly_exposed_endpoints:
-          - relayminers
       listen_url: http://0.0.0.0:8545
     - service_id: anvilws
       type: http
       service_config:
         backend_url: ws://anvil:8547/
-        publicly_exposed_endpoints:
-          - relayminers
       listen_url: ws://0.0.0.0:8545
   metrics:
     enabled: true


### PR DESCRIPTION
## Summary

Removes `publicly_exposed_endpoints` from the [`RelayMinerSupplierConfig`](https://github.com/pokt-network/poktroll/blob/6ffd2379a486570895afec8766a6a2741f92ef16/pkg/relayer/config/types.go#L150).

## Issue

- https://github.com/pokt-network/poktroll/issues/1247