### PR TITLE
[MERGE AFTER poktroll#1444][Faucet] log level flag consolidated

### DIFF
--- a/charts/pocketd-faucet/templates/deployment.yaml
+++ b/charts/pocketd-faucet/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
               --keyring-backend={{ .Values.flags.keyring_backend }};
 
               pocketd faucet serve \
-              --log-level={{ .Values.flags.log_level }} \
+              --log_level={{ .Values.flags.log_level }} \
               {{- if ne .Values.flags.node ""}}
               --node={{ .Values.flags.node }} \
               {{- end }}


### PR DESCRIPTION
https://github.com/pokt-network/poktroll/pull/1444 removes `--log-level` flag in favor of the cosmos-sdk conventional `--log_level` flag.

(waiting on poktroll#1444 to merge before merging)